### PR TITLE
Release/2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0
+
+- Bumped the minimum required Dart SDK version to `2.17.5`.
+- Removed lints.
+  - `always_put_required_named_parameters_first`
+
 ## 1.0.2
 
 - Described the reason for `invalid_annotation_target: ignore`

--- a/lib/recommended.yaml
+++ b/lib/recommended.yaml
@@ -37,7 +37,7 @@ linter: # https://dart-lang.github.io/linter/lints/
     # Style Rules
     - always_declare_return_types
     - always_put_control_body_on_new_line
-    - always_put_required_named_parameters_first
+    #- always_put_required_named_parameters_first # use as you like
     #- always_specify_types # exclude to use avoid_types_on_closure_parameters, omit_local_variable_types
     - avoid_annotating_with_dynamic
     - avoid_bool_literals_in_conditional_expressions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.2
 homepage: https://github.com/blendthink/flutter-mobile-lints
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.5 <3.0.0"
 
 dependencies:
   flutter_lints: ^2.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: blendthink_lints
 description: Recommended by blendthink set of lints for Flutter mobile apps to encourage good coding practices.
-version: 1.0.2
+version: 2.0.0
 homepage: https://github.com/blendthink/flutter-mobile-lints
 
 environment:


### PR DESCRIPTION
## Issue

close #19, close #20 

## Overview

- Bumped the minimum required Dart SDK version to `2.17.5`.
- Removed lints.
  - `always_put_required_named_parameters_first`