### PR TITLE
Release/3.0.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,7 +11,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
-    if: github.event.pull_request.merged == true && startswith(github.head_ref, 'release/')
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 3.0.0
+
+- Bumped the minimum required Dart SDK version to `2.18.0`.
+- Removed `exclude:` specification
+  - Use `ignore_for_file` with build.yaml instead.
+- Removed `invalid_annotation_target: ignore`
+  - If you are using freezed, add it to analysis_options.yaml.
+- Added Lints.
+  - `unnecessary_to_list_in_spreads`
+  - `unnecessary_null_aware_operator_on_extension_on_nullable`
+- Removed Lints.
+  - `invariant_booleans`
+
+### Reference
+
+- https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2180
+- https://pub.dev/packages/source_gen#configuring-combining_builder-ignore_for_file
+- https://github.com/rrousselGit/freezed/issues/488
+- https://github.com/dart-lang/linter/releases/tag/1.23.0
+- https://github.com/dart-lang/linter/releases/tag/1.24.0
+- https://github.com/dart-lang/linter/releases/tag/1.25.0
+- https://dart-lang.github.io/linter/lints/unnecessary_to_list_in_spreads.html
+- https://dart-lang.github.io/linter/lints/unnecessary_null_aware_operator_on_extension_on_nullable.html
+- https://dart-lang.github.io/linter/lints/invariant_booleans.html
+
 ## 2.0.0
 
 - Bumped the minimum required Dart SDK version to `2.17.5`.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "3.0.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   collection:
     dependency: transitive
     description:
@@ -47,14 +47,14 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -68,4 +68,4 @@ packages:
     source: hosted
     version: "2.1.2"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A example of blendthink_lints.
 version: 1.0.0
 publish_to: 'none'
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/lib/recommended.yaml
+++ b/lib/recommended.yaml
@@ -8,10 +8,6 @@ analyzer:
     missing_required_param: warning
     missing_return: warning
     invalid_annotation_target: ignore # Reason: https://github.com/rrousselGit/freezed/issues/488
-  exclude:
-    - "**/*.g.dart"
-    - "**/*.freezed.dart"
-    - "**/*.mocks.dart"
 
 linter: # https://dart-lang.github.io/linter/lints/
   rules:

--- a/lib/recommended.yaml
+++ b/lib/recommended.yaml
@@ -101,6 +101,7 @@ linter: # https://dart-lang.github.io/linter/lints/
     - unnecessary_await_in_return
     #- unnecessary_final # exclude to use prefer_final_locals
     - unnecessary_lambdas
+    - unnecessary_null_aware_operator_on_extension_on_nullable
     - unnecessary_null_checks # experimental
     - unnecessary_parenthesis
     - unnecessary_raw_strings

--- a/lib/recommended.yaml
+++ b/lib/recommended.yaml
@@ -36,6 +36,7 @@ linter: # https://dart-lang.github.io/linter/lints/
     #- always_put_required_named_parameters_first # use as you like
     #- always_specify_types # exclude to use avoid_types_on_closure_parameters, omit_local_variable_types
     - avoid_annotating_with_dynamic
+    #- avoid_as # deprecated
     - avoid_bool_literals_in_conditional_expressions
     - avoid_catches_without_on_clauses
     - avoid_catching_errors
@@ -79,6 +80,7 @@ linter: # https://dart-lang.github.io/linter/lints/
     - parameter_assignments
     - prefer_asserts_in_initializer_lists
     #- prefer_asserts_with_message # use as you like
+    #- prefer_bool_in_asserts # deprecated
     - prefer_constructors_over_static_methods
     #- prefer_double_quotes # exclude to use prefer_single_quotes
     #- prefer_expression_function_bodies # use as you like
@@ -96,6 +98,7 @@ linter: # https://dart-lang.github.io/linter/lints/
     - sized_box_shrink_expand
     - sort_constructors_first
     - sort_unnamed_constructors_first
+    #- super_goes_last # deprecated
     - tighten_type_of_initializing_formals
     - type_annotate_public_apis
     - unawaited_futures

--- a/lib/recommended.yaml
+++ b/lib/recommended.yaml
@@ -104,6 +104,7 @@ linter: # https://dart-lang.github.io/linter/lints/
     - unnecessary_null_checks # experimental
     - unnecessary_parenthesis
     - unnecessary_raw_strings
+    - unnecessary_to_list_in_spreads
     - use_colored_box
     - use_decorated_box
     - use_enums # experimental

--- a/lib/recommended.yaml
+++ b/lib/recommended.yaml
@@ -20,6 +20,7 @@ linter: # https://dart-lang.github.io/linter/lints/
     - close_sinks
     - comment_references
     #- diagnostic_describe_all_properties # use as you like
+    #- discarded_futures # use as you like
     - invariant_booleans # experimental
     - literal_only_boolean_expressions
     - no_adjacent_strings_in_list

--- a/lib/recommended.yaml
+++ b/lib/recommended.yaml
@@ -7,7 +7,6 @@ analyzer:
   errors: # https://dart.dev/tools/diagnostic-messages
     missing_required_param: warning
     missing_return: warning
-    invalid_annotation_target: ignore # Reason: https://github.com/rrousselGit/freezed/issues/488
 
 linter: # https://dart-lang.github.io/linter/lints/
   rules:

--- a/lib/recommended.yaml
+++ b/lib/recommended.yaml
@@ -21,7 +21,7 @@ linter: # https://dart-lang.github.io/linter/lints/
     - comment_references
     #- diagnostic_describe_all_properties # use as you like
     #- discarded_futures # use as you like
-    - invariant_booleans # experimental
+    #- invariant_booleans # deprecated
     - literal_only_boolean_expressions
     - no_adjacent_strings_in_list
     #- prefer_relative_imports # exclude to use always_use_package_imports

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: blendthink_lints
 description: Recommended by blendthink set of lints for Flutter mobile apps to encourage good coding practices.
-version: 2.0.0
+version: 3.0.0
 homepage: https://github.com/blendthink/flutter-mobile-lints
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.0.0
 homepage: https://github.com/blendthink/flutter-mobile-lints
 
 environment:
-  sdk: ">=2.17.5 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
   flutter_lints:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  flutter_lints:
+  flutter_lints: ^2.0.1
 
 dev_dependencies:
   grinder: ^0.9.2


### PR DESCRIPTION
## Overview

- Bumped the minimum required Dart SDK version to `2.18.0`.
- Removed `exclude:` specification
  - Use `ignore_for_file` with build.yaml instead.
- Removed `invalid_annotation_target: ignore`
  - If you are using freezed, add it to analysis_options.yaml.
- Added Lints.
  - `unnecessary_to_list_in_spreads`
  - `unnecessary_null_aware_operator_on_extension_on_nullable`
- Removed Lints.
  - `invariant_booleans`

### Reference

- https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#2180
- https://pub.dev/packages/source_gen#configuring-combining_builder-ignore_for_file
- https://github.com/rrousselGit/freezed/issues/488
- https://github.com/dart-lang/linter/releases/tag/1.23.0
- https://github.com/dart-lang/linter/releases/tag/1.24.0
- https://github.com/dart-lang/linter/releases/tag/1.25.0
- https://dart-lang.github.io/linter/lints/unnecessary_to_list_in_spreads.html
- https://dart-lang.github.io/linter/lints/unnecessary_null_aware_operator_on_extension_on_nullable.html
- https://dart-lang.github.io/linter/lints/invariant_booleans.html

## Issues

- Close #12 
- Close #13 
- #17 